### PR TITLE
break edit full idea function out into smaller parts

### DIFF
--- a/app/assets/javascripts/edit_idea_content.js
+++ b/app/assets/javascripts/edit_idea_content.js
@@ -40,33 +40,44 @@ function saveEditedBody(id, ideaBody){
 
 function editFullIdea(id){
   $('#edit-idea-button' + id).on('click', function(){
-    $('#edit-idea' + id).show();
-
-    $('#edit-idea-button' + id).hide();
-
+    showEditFields(id)
     $('#save-edit' + id).on('click', function(){
-      var ideaTitle = $('#edit-idea-title-text' + id).val();
-      var ideaBody = $('#edit-idea-body-text' + id).val();
-      var ideaObject = {
-        idea: {
-          title: ideaTitle,
-          body: ideaBody
-        }
-      };
-      $.ajax({
-        type: 'PUT',
-        url: '/api/v1/ideas/' + id + '.json',
-        data: ideaObject,
-        success: function(){
-          $('#idea-title' + id).html(ideaTitle);
-          $('#idea-body' + id).html(ideaBody);
-          closeEditFields(id);
-        }
-    });
-  })
+      saveEditedIdea(id)
+    })
     cancelEdit(id);
   })
 };
+
+function getNewIdeaValues(id){
+  var ideaTitle = $('#edit-idea-title-text' + id).val();
+  var ideaBody = $('#edit-idea-body-text' + id).val();
+  return ideaObject = {
+    idea: {
+      title: ideaTitle,
+      body: ideaBody
+    }
+  };
+}
+
+function saveEditedIdea(id){
+  var ideaObject = getNewIdeaValues(id)
+
+  $.ajax({
+    type: 'PUT',
+    url: '/api/v1/ideas/' + id + '.json',
+    data: ideaObject,
+    success: function(){
+      $('#idea-title' + id).html(ideaObject.idea.title);
+      $('#idea-body' + id).html(ideaObject.idea.body);
+      closeEditFields(id);
+    }
+  });
+}
+
+function showEditFields(id){
+  $('#edit-idea' + id).show();
+  $('#edit-idea-button' + id).hide();
+}
 
 function closeEditFields(id){
   $('#edit-idea' + id).hide();


### PR DESCRIPTION
@rrgayhart @jillmd501
#### What's this PR do?

This PR edits the editFullIdea() function which previously handled the entire process of clicking edit, finding DOM elements and saving to database.
#### Where should the reviewer start?

To review, take a look at files changed; all changed are within one file and new methods can be seen in changes.
#### How should this be manually tested?

You can pull down this branch and run test suite by running `rake test` as well as visiting the site on localhost by running `rails s` and clicking "Edit" button under an existing idea.
#### Any background context you want to provide?

This was previously a fairly long method (over 25 lines) and handled way too much functionality.  This PR breaks up that responsibility into smaller functions.
#### What gif best describes this PR or how it makes you feel?

![dance](https://media.giphy.com/media/CpfSSEsP7EHza/giphy.gif)
